### PR TITLE
Update Vagrant settings (minor changes)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "precise32"
+  config.vm.box = "hashicorp/precise64"
   config.vm.network :private_network, ip: "192.168.33.10"
   config.vm.synced_folder ".", "/vagrant", :mount_options => ['dmode=775', 'fmode=664']
   config.vm.provision "shell", :path => "provision.sh"

--- a/provision.sh
+++ b/provision.sh
@@ -3,7 +3,7 @@
 if ! [ `which add-apt-repository` ]; then
 	apt-get install -y python-software-properties
 	apt-get update -y
-	apt-add-repository -y ppa:rquillo/ansible
+	apt-add-repository -y ppa:ansible/ansible
 fi
 
 if ! [ `which ansible` ]; then
@@ -11,4 +11,4 @@ if ! [ `which ansible` ]; then
 	apt-get install -y ansible
 fi
 
-ansible-playbook -i /vagrant/ansible/hosts /vagrant/ansible/site.yml
+PYTHONUNBUFFERED=1 ansible-playbook -i /vagrant/ansible/hosts /vagrant/ansible/site.yml


### PR DESCRIPTION
- use implicit vagrantcloud box name (requires Vagrant 1.5+)
- switch to official ppa:ansible/ansible packages
- run ansible-playbook with PYTHONUNBUFFERED=1 to get fluent console
  output during provisioning
